### PR TITLE
Add ragged output

### DIFF
--- a/R/nn.R
+++ b/R/nn.R
@@ -25,8 +25,9 @@
 #'@param k The maximum number of nearest neighbours to compute. The default
 #'  value is set to the smaller of the number of columns in data
 #'@param eps Error bound: default of 0.0 implies exact nearest neighbour search
-#'@param radius Optional: Set to some non-zero positive number to do a fixed radius
-#'nearest neighbour search
+#'@param radius Optional: Only return points within a fixed radius.
+#'  A negative number will return a \code{list} of variable length \code{vectors}
+#'  rather than a \code{matrix} of width k.
 #'@return A \code{list} of length 2 with elements:
 #'
 #'  \item{nn.idx}{A \bold{N} x \bold{k} integer \code{matrix} returning the near
@@ -74,9 +75,6 @@ nn2 <- function(data, query=data, k=min(10,nrow(data)), eps=0.0, radius = NA)
   if(eps < 0)
     stop("Epsilon cannot be smaller than 0")
 
-  if(!is.na(radius) & radius <= 0)
-    stop("Radius must be some postive non-zero number")
-
   # Coerce to matrix form
   if(!is.matrix(data))
     data <- as.matrix(data, rownames.force = FALSE)
@@ -89,4 +87,3 @@ nn2 <- function(data, query=data, k=min(10,nrow(data)), eps=0.0, radius = NA)
 
   nn2_cpp(data, query=query, k=k, eps=eps, radius=radius)
 }
-

--- a/inst/include/WANN.h
+++ b/inst/include/WANN.h
@@ -38,6 +38,8 @@ public:
 
   List query_FR(NumericMatrix query, const int k, const double radius, const double eps=0.0);
 
+  List query_FR_ragged(NumericMatrix query, const int k, const double radius, const double eps=0.0);
+
   List querySelf(const int k, const double eps=0.0) {
     return queryANN_FR(data_pts, n, k, eps);
   }

--- a/man/nn2.Rd
+++ b/man/nn2.Rd
@@ -19,8 +19,9 @@ value is set to the smaller of the number of columns in data}
 
 \item{eps}{Error bound: default of 0.0 implies exact nearest neighbour search}
 
-\item{radius}{Optional: Set to some non-zero positive number to do a fixed radius
-nearest neighbour search}
+\item{radius}{Optional: Only return points within a fixed radius.
+A negative number will return a \code{list} of variable length \code{vectors}
+rather than a \code{matrix} of width k.}
 }
 \value{
 A \code{list} of length 2 with elements:

--- a/src/nn.cpp
+++ b/src/nn.cpp
@@ -9,6 +9,12 @@ using namespace Rcpp;
 List nn2_cpp(NumericMatrix data, NumericMatrix query, const int k, const double eps = 0.0, const double radius = NA_REAL) {
 
   WANN tree = WANN(data);
-  // NB this method will do a regular search when radius=0 or NA
-  return tree.query_FR(query, k, radius, eps);
+
+  if(!R_IsNA(radius) && radius < 0.0){
+    // this will return a ragged list of vectors allowing searches with highly variable numbers of neighbors
+    return tree.query_FR_ragged(query, k, abs(radius), eps);
+  }else{
+    // NB this method will do a regular search when radius=0 or NA
+    return tree.query_FR(query, k, radius, eps);
+  }
 }


### PR DESCRIPTION
First, I really like this package, thanks for putting it together.  It absolutely shreds the homebrewed brute force neighbors program I was using before.

I tend to run alot radius based queries that can have anywhere from zero to thousands of neighbors.  In these cases outputting a matrix of neighbor indices is inefficient because it's largely NA.  For me, a list of variable length vectors is better.  I added a feature to accomplish this by giving the nn2 function a negative radius.  This could be done with another parameter, but I think  tying it to the radius makes sense since you'd only ever want to do this for a radius based query.

I also modified the loop that populates the output by limiting it to the number of neighbors found rather than k.  annkFRSearch actually already output the number of neighbors within the radius, it just wasn't used before.  This allows you to use very large k values without looping over huge amounts of empty values just to set them to NA.

Here's an example using the ragged output:

```{r}
library(RANN2)
x1 <- runif(100, 0, 2*pi)
x2 <- runif(100, 0,3)
DATA <- data.frame(x1, x2)
QUERY <- data.frame(x1, x2)+0.5
nearest <- nn2(DATA,DATA+0.5, k=100, radius = -2, eps=0)
i = 1
plot(DATA$x1, DATA$x2)
points(DATA$x1[nearest[[1]][[i]]], DATA$x2[nearest[[1]][[i]]], col = 'green')
points(QUERY$x1[i], QUERY$x2[i], col='red')
```

Compared to the original output:

```{r}
nearest <- nn2(DATA,DATA+0.5, k=100, radius = 2, eps=0)
i = 1
plot(DATA$x1, DATA$x2)
points(DATA$x1[nearest[[1]][i,]], DATA$x2[nearest[[1]][i,]], col = 'green')
points(QUERY$x1[i], QUERY$x2[i], col='red')
```

My C++ skills are pretty weak but hopefully this is good enough to be added and help some people.  If not hopefully someone with better skills can implement a similar feature even better.  Thanks!

-Donny